### PR TITLE
Add missing atomic include

### DIFF
--- a/organic.cpp
+++ b/organic.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <algorithm>
 #include <limits>
+#include <atomic>
 #include <cassert>   // per assert di sviluppo (disabilitato in release con NDEBUG)
 
 using namespace c74::min;


### PR DESCRIPTION
## Summary
- include `<atomic>` in organic.cpp to ensure atomic operations compile

## Testing
- `g++ -std=c++17 -c organic.cpp` *(fails: missing dependency c74_min.h)*

------
https://chatgpt.com/codex/tasks/task_e_68e299ba1830832a8c61a479458e4e50