### PR TITLE
Fix organic.noise~ registration for updated Min API

### DIFF
--- a/organic.cpp
+++ b/organic.cpp
@@ -870,7 +870,9 @@ private:
     inline double pull_ola(){ double y = undenorm(olaring[ola_rd]); olaring[ola_rd] = 0.0; ola_rd = (ola_rd+1) % (int)olaring.size(); return y; }
 };
 
-MIN_EXTERNAL(organic_noise_tilde, "organic.noise~");
+extern "C" void ext_main(void* r) {
+    c74::min::wrap_as_max_external<organic_noise_tilde>("organic_noise_tilde", "organic.noise~", r);
+}
 
 /*
 README (inline)


### PR DESCRIPTION
## Summary
- replace the obsolete MIN_EXTERNAL macro invocation with an explicit ext_main wrapper that names the Max external "organic.noise~"

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2b452e1c0832a8d0073df73e7bb02