### PR TITLE
Fix output buffer handling when processing audio bundles

### DIFF
--- a/organic.cpp
+++ b/organic.cpp
@@ -538,7 +538,16 @@ public:
     organic_noise_tilde() = default;
 
     void operator()(audio_bundle in, audio_bundle out) {
-        const double* in1p = in.samples(0); double* L = out.samples(0); double* R = out.samples(1); auto vs = in.frame_count();
+        double* L = out.samples(0);
+        if (!L)
+            return;
+
+        double* R = out.samples(1);
+        if (!R)
+            R = L;
+
+        const double* in1p = in.samples(0);
+        const size_t vs = out.frame_count();
         const bool  use_smr = (mode == symbol{"smr"});
         const double cf_v   = (double)crossfeed;
 


### PR DESCRIPTION
## Summary
- guard against null audio output buffers before processing
- drive processing from the output frame count so the operator runs even without an input signal

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2b8318500832a9b35f9456fa61648