### PR TITLE
Fix audio output fallback when a channel is disconnected

### DIFF
--- a/organic.cpp
+++ b/organic.cpp
@@ -539,15 +539,18 @@ public:
 
     void operator()(audio_bundle in, audio_bundle out) {
         double* L = out.samples(0);
-        if (!L)
+        double* R = out.samples(1);
+
+        if (!L && !R)
             return;
 
-        double* R = out.samples(1);
+        if (!L)
+            L = R;
         if (!R)
             R = L;
 
         const double* in1p = in.samples(0);
-        const size_t vs = out.frame_count();
+        const size_t vs = in.frame_count();
         const bool  use_smr = (mode == symbol{"smr"});
         const double cf_v   = (double)crossfeed;
 
@@ -725,7 +728,7 @@ public:
             if(use_smr){
                 double wet = pull_ola();
                 if(!std::isfinite(wet)) wet = 0.0;
-                wet_smr = wet;
+                wet_smr = (std::fabs(wet) > 1e-12) ? wet : wet_core;
             }
 
             // Blend dry/wet globale


### PR DESCRIPTION
## Summary
- ensure the DSP callback continues when only one outlet is connected by mirroring the available buffer to the missing channel
- derive the vector size from the input bundle to stay consistent with Max's callback contract
- guard the SMR wet signal by falling back to the core output when the overlap-add buffer is effectively empty

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2bd10cc48832a9256a4dfd33b88f3